### PR TITLE
Instruction timing propagation from simulator

### DIFF
--- a/paragraph/scheduling/graph_scheduler.cc
+++ b/paragraph/scheduling/graph_scheduler.cc
@@ -17,7 +17,8 @@
 namespace paragraph {
 
 GraphScheduler::GraphScheduler(Graph* graph)
-    : graph_(graph) {}
+    : graph_(graph),
+      current_time_(0.0) {}
 
 shim::StatusOr<std::unique_ptr<GraphScheduler>> GraphScheduler::Create(
     Graph* graph) {
@@ -47,17 +48,31 @@ shim::StatusOr<std::unique_ptr<GraphScheduler>> GraphScheduler::Create(
           InstructionFsm(scheduler.get(), instruction.get()));
     }
   }
-  // Reset all FSMs recursively starting from entry subroutine
-  scheduler->GetFsm(scheduler->graph_->GetEntrySubroutine()).Reset();
-  // Moves available to be scheduled instructions from entry subroutine to the
-  // scheduling queue
-  RETURN_IF_ERROR(scheduler->GetFsm(
-      scheduler->graph_->GetEntrySubroutine()).PrepareToSchedule());
   return scheduler;
 }
 
-void GraphScheduler::InstructionFinished(Instruction* instruction) {
+absl::Status GraphScheduler::Init(double seconds) {
+  current_time_ = seconds;
+  // Reset all FSMs recursively starting from entry subroutine
+  GetFsm(graph_->GetEntrySubroutine()).Reset();
+  // Moves available to be scheduled instructions from entry subroutine to the
+  // scheduling queue
+  RETURN_IF_ERROR(
+      GetFsm(graph_->GetEntrySubroutine()).PrepareToSchedule());
+  return absl::OkStatus();
+}
+
+void GraphScheduler::InstructionStarted(
+    Instruction* instruction, double seconds) {
+  current_time_ = seconds;
+  GetFsm(instruction).SetTimeStarted(seconds);
+}
+
+void GraphScheduler::InstructionFinished(
+    Instruction* instruction, double seconds) {
+  current_time_ = seconds;
   GetFsm(instruction).SetFinished();
+  GetFsm(instruction).SetTimeFinished(seconds);
   CHECK_OK(GetFsm(instruction->GetParent()).InstructionFinished(instruction));
   for (auto& user : instruction->Users()) {
     if (GetFsm(user).IsUnblockedByOperands()) {
@@ -107,6 +122,9 @@ SubroutineFsm& GraphScheduler::GetFsm(const Subroutine* subroutine) {
       << " Graph might not be valid.";
   return subroutine_state_map_.at(subroutine);
 }
+
+double GraphScheduler::GetCurrentTime() { return current_time_; }
+void GraphScheduler::SetCurrentTime(double seconds) { current_time_ = seconds; }
 
 void GraphScheduler::SeedRandom(uint64_t seed) {
   std::seed_seq seq = {(uint32_t)((seed >> 32) & 0xFFFFFFFFlu),

--- a/paragraph/scheduling/graph_scheduler.h
+++ b/paragraph/scheduling/graph_scheduler.h
@@ -39,10 +39,15 @@ class GraphScheduler {
   ~GraphScheduler() = default;
 
   // Creates a new scheduler and verifies the that graph is ready to be
-  // scheduled
+  // scheduled.
   // Part of Public API with simulators
   static shim::StatusOr<std::unique_ptr<GraphScheduler>> Create(
       Graph* graph);
+
+  // Initializes graph execution and sets time when available instructions are
+  // ready. Can be performed much later after scheduler creation.
+  // Part of Public API with simulators
+  absl::Status Init(double seconds = 0.0);
 
   // Provides all instructions ready for scheduling to Simulator
   // Part of Public API with simulators
@@ -52,7 +57,11 @@ class GraphScheduler {
 
   // Marks instruction as Finished in Simulator
   // Part of Public API with simulators
-  void InstructionFinished(Instruction* instruction);
+  void InstructionStarted(Instruction* instruction, double seconds);
+
+  // Marks instruction as Finished in Simulator
+  // Part of Public API with simulators
+  void InstructionFinished(Instruction* instruction, double seconds);
 
   // Seeds internal PRNG
   // The scheduler makes decisions about the order in which some subroutines are
@@ -64,6 +73,10 @@ class GraphScheduler {
   InstructionFsm& GetFsm(const Instruction* instruction);
   SubroutineFsm& GetFsm(const Subroutine* subroutine);
 
+  // Getter/Setter for current simulation time
+  double GetCurrentTime();
+  void SetCurrentTime(double seconds);
+
  private:
   // Private constructor to ensure that graph is valid before it gets scheduled,
   // and also to link scheduler with instructions/subroutines FSMs
@@ -71,6 +84,10 @@ class GraphScheduler {
 
   // Graph to be scheduled
   Graph* graph_;
+
+  // Current simulation time set and updated by simulator every time when public
+  // API is used.
+  double current_time_;
 
   // Scheduler instruction queue
   std::vector<Instruction*> ready_to_schedule_;

--- a/paragraph/scheduling/graph_scheduler.h
+++ b/paragraph/scheduling/graph_scheduler.h
@@ -47,7 +47,7 @@ class GraphScheduler {
   // Initializes graph execution and sets time when available instructions are
   // ready. Can be performed much later after scheduler creation.
   // Part of Public API with simulators
-  absl::Status Init(double seconds = 0.0);
+  absl::Status Initialize(double current_time);
 
   // Provides all instructions ready for scheduling to Simulator
   // Part of Public API with simulators
@@ -57,11 +57,11 @@ class GraphScheduler {
 
   // Marks instruction as Finished in Simulator
   // Part of Public API with simulators
-  void InstructionStarted(Instruction* instruction, double seconds);
+  void InstructionStarted(Instruction* instruction, double current_time);
 
   // Marks instruction as Finished in Simulator
   // Part of Public API with simulators
-  void InstructionFinished(Instruction* instruction, double seconds);
+  void InstructionFinished(Instruction* instruction, double current_time);
 
   // Seeds internal PRNG
   // The scheduler makes decisions about the order in which some subroutines are
@@ -73,9 +73,8 @@ class GraphScheduler {
   InstructionFsm& GetFsm(const Instruction* instruction);
   SubroutineFsm& GetFsm(const Subroutine* subroutine);
 
-  // Getter/Setter for current simulation time
-  double GetCurrentTime();
-  void SetCurrentTime(double seconds);
+  // Getter for current simulation time
+  double GetCurrentTime() const;
 
  private:
   // Private constructor to ensure that graph is valid before it gets scheduled,

--- a/paragraph/scheduling/graph_scheduler_test.cc
+++ b/paragraph/scheduling/graph_scheduler_test.cc
@@ -40,11 +40,8 @@ TEST(Scheduler, Timing) {
                        paragraph::GraphScheduler::Create(graph.get()));
   EXPECT_EQ(scheduler->GetCurrentTime(), 0.0);
 
-  CHECK_OK(scheduler->Init(10.0));
+  CHECK_OK(scheduler->Initialize(10.0));
   EXPECT_EQ(scheduler->GetCurrentTime(), 10.0);
-
-  scheduler->SetCurrentTime(20.0);
-  EXPECT_EQ(scheduler->GetCurrentTime(), 20.0);
 
   scheduler->InstructionStarted(instr_1, 30.0);
   EXPECT_EQ(scheduler->GetCurrentTime(), 30.0);
@@ -109,7 +106,7 @@ TEST(Scheduler, Creation) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
-  CHECK_OK(scheduler->Init());
+  CHECK_OK(scheduler->Initialize(0.0));
 
   EXPECT_TRUE(scheduler->GetFsm(sub_ptr).IsScheduled());
   EXPECT_TRUE(scheduler->GetFsm(body_sub_ptr).IsScheduled());
@@ -184,7 +181,7 @@ TEST(Scheduler, WhileInstruction) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
-  CHECK_OK(scheduler->Init());
+  CHECK_OK(scheduler->Initialize(0.0));
 
   auto consumed_instructions = scheduler->GetReadyInstructions();
   EXPECT_EQ(consumed_instructions.size(), 3);
@@ -277,7 +274,7 @@ TEST(Scheduler, NullInstruction) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
-  CHECK_OK(scheduler->Init());
+  CHECK_OK(scheduler->Initialize(0.0));
 
   auto consumed_instructions = scheduler->GetReadyInstructions();
   EXPECT_EQ(consumed_instructions.size(), 3);
@@ -396,7 +393,7 @@ entry_subroutine {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
-  CHECK_OK(scheduler->Init());
+  CHECK_OK(scheduler->Initialize(0.0));
 
   auto consumed_instructions = scheduler->GetReadyInstructions();
   EXPECT_EQ(consumed_instructions.size(), 1);
@@ -470,7 +467,7 @@ TEST(Scheduler, GetReadyInstructionQueue) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
-  CHECK_OK(scheduler->Init());
+  CHECK_OK(scheduler->Initialize(0.0));
 
   std::queue<paragraph::Instruction*> queue;
   scheduler->GetReadyInstructions(queue);

--- a/paragraph/scheduling/graph_scheduler_test.cc
+++ b/paragraph/scheduling/graph_scheduler_test.cc
@@ -26,6 +26,34 @@
 #include "paragraph/shim/test_macros.h"
 
 // Tests scheduler creation and access to instructions/subroutines FSMs
+TEST(Scheduler, Timing) {
+  auto graph = absl::make_unique<paragraph::Graph>("test_graph", 1);
+  auto sub = absl::make_unique<paragraph::Subroutine>(
+      "test_subroutine", graph.get());
+  auto sub_ptr = sub.get();
+  graph->SetEntrySubroutine(std::move(sub));
+
+  ASSERT_OK_AND_ASSIGN(auto instr_1, paragraph::Instruction::Create(
+      paragraph::Opcode::kInfeed, "compute_pred1", sub_ptr, true));
+
+  ASSERT_OK_AND_ASSIGN(auto scheduler,
+                       paragraph::GraphScheduler::Create(graph.get()));
+  EXPECT_EQ(scheduler->GetCurrentTime(), 0.0);
+
+  CHECK_OK(scheduler->Init(10.0));
+  EXPECT_EQ(scheduler->GetCurrentTime(), 10.0);
+
+  scheduler->SetCurrentTime(20.0);
+  EXPECT_EQ(scheduler->GetCurrentTime(), 20.0);
+
+  scheduler->InstructionStarted(instr_1, 30.0);
+  EXPECT_EQ(scheduler->GetCurrentTime(), 30.0);
+
+  scheduler->InstructionFinished(instr_1, 40.0);
+  EXPECT_EQ(scheduler->GetCurrentTime(), 40.0);
+}
+
+// Tests scheduler creation and access to instructions/subroutines FSMs
 TEST(Scheduler, Creation) {
   auto graph = absl::make_unique<paragraph::Graph>("test_graph", 1);
   auto sub = absl::make_unique<paragraph::Subroutine>(
@@ -81,6 +109,7 @@ TEST(Scheduler, Creation) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
+  CHECK_OK(scheduler->Init());
 
   EXPECT_TRUE(scheduler->GetFsm(sub_ptr).IsScheduled());
   EXPECT_TRUE(scheduler->GetFsm(body_sub_ptr).IsScheduled());
@@ -155,6 +184,7 @@ TEST(Scheduler, WhileInstruction) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
+  CHECK_OK(scheduler->Init());
 
   auto consumed_instructions = scheduler->GetReadyInstructions();
   EXPECT_EQ(consumed_instructions.size(), 3);
@@ -162,39 +192,47 @@ TEST(Scheduler, WhileInstruction) {
   EXPECT_EQ(consumed_instructions.at(1)->GetName(), "body_compute");
   EXPECT_EQ(consumed_instructions.at(2)->GetName(), "send");
 
-  scheduler->InstructionFinished(consumed_instructions.at(2));
+  scheduler->InstructionStarted(consumed_instructions.at(2), 0.0);
+  scheduler->InstructionFinished(consumed_instructions.at(2), 0.0);
   EXPECT_EQ(scheduler->GetReadyInstructions().size(), 0);
 
-  scheduler->InstructionFinished(consumed_instructions.at(0));
+  scheduler->InstructionStarted(consumed_instructions.at(0), 0.0);
+  scheduler->InstructionFinished(consumed_instructions.at(0), 0.0);
   auto reduction_line = scheduler->GetReadyInstructions();
   EXPECT_EQ(reduction_line.size(), 1);
   EXPECT_EQ(reduction_line.at(0)->GetName(), "reduction_operand1");
 
-  scheduler->InstructionFinished(reduction_line.at(0));
+  scheduler->InstructionStarted(reduction_line.at(0), 0.0);
+  scheduler->InstructionFinished(reduction_line.at(0), 0.0);
   reduction_line = scheduler->GetReadyInstructions();
   EXPECT_EQ(reduction_line.size(), 1);
   EXPECT_EQ(reduction_line.at(0)->GetName(), "reduction");
 
-  scheduler->InstructionFinished(reduction_line.at(0));
+  scheduler->InstructionStarted(reduction_line.at(0), 0.0);
+  scheduler->InstructionFinished(reduction_line.at(0), 0.0);
   reduction_line = scheduler->GetReadyInstructions();
   EXPECT_EQ(reduction_line.size(), 0);
 
-  scheduler->InstructionFinished(consumed_instructions.at(1));
+  scheduler->InstructionStarted(consumed_instructions.at(1), 0.0);
+  scheduler->InstructionFinished(consumed_instructions.at(1), 0.0);
   consumed_instructions = scheduler->GetReadyInstructions();
   EXPECT_EQ(consumed_instructions.size(), 1);
   EXPECT_EQ(consumed_instructions.at(0)->GetName(), "call_func");
 
-  scheduler->InstructionFinished(consumed_instructions.at(0));
+  scheduler->InstructionStarted(consumed_instructions.at(0), 0.0);
+  scheduler->InstructionFinished(consumed_instructions.at(0), 0.0);
   consumed_instructions = scheduler->GetReadyInstructions();
   EXPECT_EQ(consumed_instructions.size(), 1);
   EXPECT_EQ(consumed_instructions.at(0)->GetName(), "body_compute");
 
-  scheduler->InstructionFinished(consumed_instructions.at(0));
+  scheduler->InstructionStarted(consumed_instructions.at(0), 0.0);
+  scheduler->InstructionFinished(consumed_instructions.at(0), 0.0);
   consumed_instructions = scheduler->GetReadyInstructions();
   EXPECT_EQ(consumed_instructions.size(), 1);
   EXPECT_EQ(consumed_instructions.at(0)->GetName(), "call_func");
 
-  scheduler->InstructionFinished(consumed_instructions.at(0));
+  scheduler->InstructionStarted(consumed_instructions.at(0), 0.0);
+  scheduler->InstructionFinished(consumed_instructions.at(0), 0.0);
   consumed_instructions = scheduler->GetReadyInstructions();
   EXPECT_EQ(consumed_instructions.size(), 0);
 }
@@ -239,6 +277,7 @@ TEST(Scheduler, NullInstruction) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
+  CHECK_OK(scheduler->Init());
 
   auto consumed_instructions = scheduler->GetReadyInstructions();
   EXPECT_EQ(consumed_instructions.size(), 3);
@@ -246,13 +285,16 @@ TEST(Scheduler, NullInstruction) {
   EXPECT_EQ(consumed_instructions.at(1)->GetName(), "op1");
   EXPECT_EQ(consumed_instructions.at(2)->GetName(), "op2");
 
-  scheduler->InstructionFinished(consumed_instructions.at(0));
+  scheduler->InstructionStarted(consumed_instructions.at(0), 0.0);
+  scheduler->InstructionFinished(consumed_instructions.at(0), 0.0);
   EXPECT_EQ(scheduler->GetReadyInstructions().size(), 0);
 
-  scheduler->InstructionFinished(consumed_instructions.at(1));
+  scheduler->InstructionStarted(consumed_instructions.at(1), 0.0);
+  scheduler->InstructionFinished(consumed_instructions.at(1), 0.0);
   EXPECT_EQ(scheduler->GetReadyInstructions().size(), 0);
 
-  scheduler->InstructionFinished(consumed_instructions.at(2));
+  scheduler->InstructionStarted(consumed_instructions.at(2), 0.0);
+  scheduler->InstructionFinished(consumed_instructions.at(2), 0.0);
   consumed_instructions = scheduler->GetReadyInstructions();
   EXPECT_EQ(consumed_instructions.size(), 1);
   EXPECT_EQ(consumed_instructions.at(0)->GetName(), "last_instruction");
@@ -354,11 +396,13 @@ entry_subroutine {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
+  CHECK_OK(scheduler->Init());
 
   auto consumed_instructions = scheduler->GetReadyInstructions();
   EXPECT_EQ(consumed_instructions.size(), 1);
   EXPECT_EQ(consumed_instructions.at(0)->GetName(), "first_instruction");
-  scheduler->InstructionFinished(consumed_instructions.at(0));
+  scheduler->InstructionStarted(consumed_instructions.at(0), 0.0);
+  scheduler->InstructionFinished(consumed_instructions.at(0), 0.0);
 
   consumed_instructions = scheduler->GetReadyInstructions();
   EXPECT_EQ(consumed_instructions.size(), 3);
@@ -366,18 +410,22 @@ entry_subroutine {
   EXPECT_EQ(consumed_instructions.at(1)->GetName(), "op2");
   EXPECT_EQ(consumed_instructions.at(2)->GetName(), "called_func");
 
-  scheduler->InstructionFinished(consumed_instructions.at(0));
+  scheduler->InstructionStarted(consumed_instructions.at(0), 0.0);
+  scheduler->InstructionFinished(consumed_instructions.at(0), 0.0);
   EXPECT_EQ(scheduler->GetReadyInstructions().size(), 0);
 
-  scheduler->InstructionFinished(consumed_instructions.at(2));
+  scheduler->InstructionStarted(consumed_instructions.at(2), 0.0);
+  scheduler->InstructionFinished(consumed_instructions.at(2), 0.0);
   EXPECT_EQ(scheduler->GetReadyInstructions().size(), 0);
 
-  scheduler->InstructionFinished(consumed_instructions.at(1));
+  scheduler->InstructionStarted(consumed_instructions.at(1), 0.0);
+  scheduler->InstructionFinished(consumed_instructions.at(1), 0.0);
   consumed_instructions = scheduler->GetReadyInstructions();
   EXPECT_EQ(consumed_instructions.size(), 1);
   EXPECT_EQ(consumed_instructions.at(0)->GetName(), "sum");
 
-  scheduler->InstructionFinished(consumed_instructions.at(0));
+  scheduler->InstructionStarted(consumed_instructions.at(0), 0.0);
+  scheduler->InstructionFinished(consumed_instructions.at(0), 0.0);
   consumed_instructions = scheduler->GetReadyInstructions();
   EXPECT_EQ(consumed_instructions.size(), 1);
   EXPECT_EQ(consumed_instructions.at(0)->GetName(), "last_instruction");
@@ -422,6 +470,7 @@ TEST(Scheduler, GetReadyInstructionQueue) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
+  CHECK_OK(scheduler->Init());
 
   std::queue<paragraph::Instruction*> queue;
   scheduler->GetReadyInstructions(queue);

--- a/paragraph/scheduling/instruction_fsm.cc
+++ b/paragraph/scheduling/instruction_fsm.cc
@@ -82,24 +82,24 @@ double InstructionFsm::GetTimeReady() {
   return time_ready_;
 }
 
-void InstructionFsm::SetTimeReady(double seconds) {
-  time_ready_ = seconds;
+void InstructionFsm::SetTimeReady(double current_time) {
+  time_ready_ = current_time;
 }
 
 double InstructionFsm::GetTimeStarted() {
   return time_started_;
 }
 
-void InstructionFsm::SetTimeStarted(double seconds) {
-  time_started_ = seconds;
+void InstructionFsm::SetTimeStarted(double current_time) {
+  time_started_ = current_time;
 }
 
 double InstructionFsm::GetTimeFinished() {
   return time_finished_;
 }
 
-void InstructionFsm::SetTimeFinished(double seconds) {
-  time_finished_ = seconds;
+void InstructionFsm::SetTimeFinished(double current_time) {
+  time_finished_ = current_time;
 }
 
 void InstructionFsm::Reset() {

--- a/paragraph/scheduling/instruction_fsm.cc
+++ b/paragraph/scheduling/instruction_fsm.cc
@@ -54,7 +54,10 @@ shim::StatusOr<InstructionFsm::State> InstructionFsm::StringToInstructionState(
 InstructionFsm::InstructionFsm(GraphScheduler* scheduler,
                                Instruction* instruction)
     : instruction_(instruction),
-      scheduler_(scheduler) {}
+      scheduler_(scheduler),
+      time_ready_(0.0),
+      time_started_(0.0),
+      time_finished_(0.0) {}
 
 bool InstructionFsm::IsUnblockedByOperands() {
   bool unblocked = true;
@@ -74,6 +77,30 @@ bool InstructionFsm::IsExecuting() { return state_ == State::kExecuting; }
 void InstructionFsm::SetExecuting() { state_ = State::kExecuting; }
 bool InstructionFsm::IsFinished() { return state_ == State::kFinished; }
 void InstructionFsm::SetFinished() { state_ = State::kFinished; }
+
+double InstructionFsm::GetTimeReady() {
+  return time_ready_;
+}
+
+void InstructionFsm::SetTimeReady(double seconds) {
+  time_ready_ = seconds;
+}
+
+double InstructionFsm::GetTimeStarted() {
+  return time_started_;
+}
+
+void InstructionFsm::SetTimeStarted(double seconds) {
+  time_started_ = seconds;
+}
+
+double InstructionFsm::GetTimeFinished() {
+  return time_finished_;
+}
+
+void InstructionFsm::SetTimeFinished(double seconds) {
+  time_finished_ = seconds;
+}
 
 void InstructionFsm::Reset() {
   if (instruction_->Operands().empty()) {
@@ -100,16 +127,19 @@ absl::Status InstructionFsm::PrepareToSchedule() {
       // If we picked this subroutine, and it is finished, it means that
       // all subroutines are finished and parent instruction can be
       // marked finished
-      scheduler_->InstructionFinished(instruction_);
+      scheduler_->InstructionFinished(instruction_,
+                                      scheduler_->GetCurrentTime());
       return absl::OkStatus();
     }
   } else {
     // If we see Null opcode, which is ParaGraph internal opcode, we do not
     // schedule it through scheduler and just instantly execute it
     if (instruction_->GetOpcode() == Opcode::kNull) {
-      scheduler_->InstructionFinished(instruction_);
+      scheduler_->InstructionFinished(instruction_,
+                                      scheduler_->GetCurrentTime());
     } else {
       SetReady();
+      SetTimeReady(scheduler_->GetCurrentTime());
       scheduler_->EnqueueToScheduler(instruction_);
     }
   }

--- a/paragraph/scheduling/instruction_fsm.h
+++ b/paragraph/scheduling/instruction_fsm.h
@@ -77,6 +77,14 @@ class InstructionFsm {
   // Picks the next subroutine to schedule among instruction's inner subroutines
   shim::StatusOr<Subroutine*> PickSubroutine();
 
+  // Getters/Setters for instruction timings
+  double GetTimeReady();
+  void SetTimeReady(double seconds);
+  double GetTimeStarted();
+  void SetTimeStarted(double seconds);
+  double GetTimeFinished();
+  void SetTimeFinished(double seconds);
+
  private:
   // State of the instruction
   State state_;
@@ -87,6 +95,11 @@ class InstructionFsm {
   // Pointer to the graph scheduler that keeps scheduling information about
   // all subroutines and instructions in the graph
   GraphScheduler* scheduler_;
+
+  // Instruction timings
+  double time_ready_;
+  double time_started_;
+  double time_finished_;
 };
 
 }  // namespace paragraph

--- a/paragraph/scheduling/instruction_fsm.h
+++ b/paragraph/scheduling/instruction_fsm.h
@@ -79,11 +79,11 @@ class InstructionFsm {
 
   // Getters/Setters for instruction timings
   double GetTimeReady();
-  void SetTimeReady(double seconds);
+  void SetTimeReady(double current_time);
   double GetTimeStarted();
-  void SetTimeStarted(double seconds);
+  void SetTimeStarted(double current_time);
   double GetTimeFinished();
-  void SetTimeFinished(double seconds);
+  void SetTimeFinished(double current_time);
 
  private:
   // State of the instruction

--- a/paragraph/scheduling/instruction_fsm_test.cc
+++ b/paragraph/scheduling/instruction_fsm_test.cc
@@ -98,7 +98,7 @@ TEST(InstructionFsm, Timing) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
-  CHECK_OK(scheduler->Init());
+  CHECK_OK(scheduler->Initialize(0.0));
   auto instr_fsm = scheduler->GetFsm(instr);
 
   EXPECT_EQ(instr_fsm.GetTimeReady(), 0.0);
@@ -133,7 +133,7 @@ TEST(InstructionFsm, StateTransition) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
-  CHECK_OK(scheduler->Init());
+  CHECK_OK(scheduler->Initialize(0.0));
   auto instr_fsm = scheduler->GetFsm(instr);
   EXPECT_TRUE(instr_fsm.IsReady());
 
@@ -169,7 +169,7 @@ TEST(InstructionFsm, CheckUnblocked) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
-  CHECK_OK(scheduler->Init());
+  CHECK_OK(scheduler->Initialize(0.0));
 
   EXPECT_TRUE(scheduler->GetFsm(instr_1).IsUnblockedByOperands());
   EXPECT_FALSE(scheduler->GetFsm(instr_2).IsUnblockedByOperands());
@@ -194,7 +194,7 @@ TEST(InstructionFsm, ResetState) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
-  CHECK_OK(scheduler->Init());
+  CHECK_OK(scheduler->Initialize(0.0));
 
   EXPECT_TRUE(scheduler->GetFsm(instr_1).IsReady());
   EXPECT_TRUE(scheduler->GetFsm(instr_2).IsBlocked());
@@ -247,7 +247,7 @@ TEST(InstructionFsm, PrepareToSchedule) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
-  CHECK_OK(scheduler->Init());
+  CHECK_OK(scheduler->Initialize(0.0));
   // Consume first available instruction, which is dummy
   auto consumed_instructions = scheduler->GetReadyInstructions();
 
@@ -318,7 +318,7 @@ TEST(InstructionFsm, PickSubroutine) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
-  CHECK_OK(scheduler->Init());
+  CHECK_OK(scheduler->Initialize(0.0));
 
   paragraph::Subroutine* picked_subroutine;
   ASSERT_OK_AND_ASSIGN(picked_subroutine,
@@ -385,7 +385,7 @@ TEST(InstructionFsm, PickSubroutineCall) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
-  CHECK_OK(scheduler->Init(10.0));
+  CHECK_OK(scheduler->Initialize(10.0));
   EXPECT_EQ(scheduler->GetFsm(instr_1).GetTimeReady(), 10.0);
   EXPECT_EQ(scheduler->GetFsm(instr_2).GetTimeReady(), 0.0);
   EXPECT_EQ(scheduler->GetFsm(instr_3).GetTimeReady(), 0.0);

--- a/paragraph/scheduling/instruction_fsm_test.cc
+++ b/paragraph/scheduling/instruction_fsm_test.cc
@@ -86,6 +86,41 @@ TEST(InstructionFsm, StateToStringConversion) {
             "finished");
 }
 
+// Test instruction FSM timing setters and getters
+TEST(InstructionFsm, Timing) {
+  auto graph = absl::make_unique<paragraph::Graph>("test_graph", 1);
+  auto sub = absl::make_unique<paragraph::Subroutine>(
+      "test_subroutine", graph.get());
+  auto sub_ptr = sub.get();
+  graph->SetEntrySubroutine(std::move(sub));
+  ASSERT_OK_AND_ASSIGN(auto instr, paragraph::Instruction::Create(
+      paragraph::Opcode::kDelay, "dummy", sub_ptr, true));
+
+  ASSERT_OK_AND_ASSIGN(auto scheduler,
+                       paragraph::GraphScheduler::Create(graph.get()));
+  CHECK_OK(scheduler->Init());
+  auto instr_fsm = scheduler->GetFsm(instr);
+
+  EXPECT_EQ(instr_fsm.GetTimeReady(), 0.0);
+  EXPECT_EQ(instr_fsm.GetTimeStarted(), 0.0);
+  EXPECT_EQ(instr_fsm.GetTimeFinished(), 0.0);
+
+  instr_fsm.SetTimeReady(1.0);
+  EXPECT_EQ(instr_fsm.GetTimeReady(), 1.0);
+  EXPECT_EQ(instr_fsm.GetTimeStarted(), 0.0);
+  EXPECT_EQ(instr_fsm.GetTimeFinished(), 0.0);
+
+  instr_fsm.SetTimeStarted(2.0);
+  EXPECT_EQ(instr_fsm.GetTimeReady(), 1.0);
+  EXPECT_EQ(instr_fsm.GetTimeStarted(), 2.0);
+  EXPECT_EQ(instr_fsm.GetTimeFinished(), 0.0);
+
+  instr_fsm.SetTimeFinished(3.0);
+  EXPECT_EQ(instr_fsm.GetTimeReady(), 1.0);
+  EXPECT_EQ(instr_fsm.GetTimeStarted(), 2.0);
+  EXPECT_EQ(instr_fsm.GetTimeFinished(), 3.0);
+}
+
 // Tests instruction FSM state setters and getters
 TEST(InstructionFsm, StateTransition) {
   auto graph = absl::make_unique<paragraph::Graph>("test_graph", 1);
@@ -98,6 +133,7 @@ TEST(InstructionFsm, StateTransition) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
+  CHECK_OK(scheduler->Init());
   auto instr_fsm = scheduler->GetFsm(instr);
   EXPECT_TRUE(instr_fsm.IsReady());
 
@@ -133,6 +169,7 @@ TEST(InstructionFsm, CheckUnblocked) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
+  CHECK_OK(scheduler->Init());
 
   EXPECT_TRUE(scheduler->GetFsm(instr_1).IsUnblockedByOperands());
   EXPECT_FALSE(scheduler->GetFsm(instr_2).IsUnblockedByOperands());
@@ -157,6 +194,7 @@ TEST(InstructionFsm, ResetState) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
+  CHECK_OK(scheduler->Init());
 
   EXPECT_TRUE(scheduler->GetFsm(instr_1).IsReady());
   EXPECT_TRUE(scheduler->GetFsm(instr_2).IsBlocked());
@@ -209,6 +247,7 @@ TEST(InstructionFsm, PrepareToSchedule) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
+  CHECK_OK(scheduler->Init());
   // Consume first available instruction, which is dummy
   auto consumed_instructions = scheduler->GetReadyInstructions();
 
@@ -279,6 +318,7 @@ TEST(InstructionFsm, PickSubroutine) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
+  CHECK_OK(scheduler->Init());
 
   paragraph::Subroutine* picked_subroutine;
   ASSERT_OK_AND_ASSIGN(picked_subroutine,
@@ -313,7 +353,7 @@ TEST(InstructionFsm, PickSubroutine) {
   EXPECT_LE(abs(counter.at(0) + counter.at(2) - counter.at(1)), 200);
 }
 
-// Tests PickSubroutine() method with Call instruction
+// Tests PickSubroutine() method with Call instruction and timings
 TEST(InstructionFsm, PickSubroutineCall) {
   auto graph = absl::make_unique<paragraph::Graph>("test_graph", 1);
   auto sub = absl::make_unique<paragraph::Subroutine>(
@@ -345,6 +385,10 @@ TEST(InstructionFsm, PickSubroutineCall) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
+  CHECK_OK(scheduler->Init(10.0));
+  EXPECT_EQ(scheduler->GetFsm(instr_1).GetTimeReady(), 10.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_2).GetTimeReady(), 0.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_3).GetTimeReady(), 0.0);
   EXPECT_TRUE(scheduler->GetFsm(sub_1_ptr).IsScheduled());
   EXPECT_TRUE(scheduler->GetFsm(sub_2_ptr).IsBlocked());
   EXPECT_TRUE(scheduler->GetFsm(sub_3_ptr).IsBlocked());
@@ -353,17 +397,53 @@ TEST(InstructionFsm, PickSubroutineCall) {
   ASSERT_OK_AND_ASSIGN(picked_subroutine,
                        scheduler->GetFsm(call).PickSubroutine());
   EXPECT_EQ(picked_subroutine->GetName(), "subroutine_1");
-  scheduler->InstructionFinished(instr_1);
+  EXPECT_EQ(scheduler->GetFsm(instr_1).GetTimeReady(), 10.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_1).GetTimeStarted(), 0.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_1).GetTimeFinished(), 0.0);
+
+  scheduler->InstructionStarted(instr_1, 15.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_1).GetTimeReady(), 10.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_1).GetTimeStarted(), 15.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_1).GetTimeFinished(), 0.0);
+
+  scheduler->InstructionFinished(instr_1, 20.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_1).GetTimeReady(), 10.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_1).GetTimeStarted(), 15.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_1).GetTimeFinished(), 20.0);
 
   ASSERT_OK_AND_ASSIGN(picked_subroutine,
                        scheduler->GetFsm(call).PickSubroutine());
   EXPECT_EQ(picked_subroutine->GetName(), "subroutine_2");
-  scheduler->InstructionFinished(instr_2);
+  EXPECT_EQ(scheduler->GetFsm(instr_2).GetTimeReady(), 20.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_2).GetTimeStarted(), 0.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_2).GetTimeFinished(), 0.0);
+
+  scheduler->InstructionStarted(instr_2, 25.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_2).GetTimeReady(), 20.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_2).GetTimeStarted(), 25.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_2).GetTimeFinished(), 0.0);
+
+  scheduler->InstructionFinished(instr_2, 30.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_2).GetTimeReady(), 20.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_2).GetTimeStarted(), 25.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_2).GetTimeFinished(), 30.0);
 
   ASSERT_OK_AND_ASSIGN(picked_subroutine,
                        scheduler->GetFsm(call).PickSubroutine());
   EXPECT_EQ(picked_subroutine->GetName(), "subroutine_3");
-  scheduler->InstructionFinished(instr_3);
+  EXPECT_EQ(scheduler->GetFsm(instr_3).GetTimeReady(), 30.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_3).GetTimeStarted(), 0.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_3).GetTimeFinished(), 0.0);
+
+  scheduler->InstructionStarted(instr_3, 35.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_3).GetTimeReady(), 30.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_3).GetTimeStarted(), 35.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_3).GetTimeFinished(), 0.0);
+
+  scheduler->InstructionFinished(instr_3, 40.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_3).GetTimeReady(), 30.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_3).GetTimeStarted(), 35.0);
+  EXPECT_EQ(scheduler->GetFsm(instr_3).GetTimeFinished(), 40.0);
 
   EXPECT_TRUE(scheduler->GetFsm(call).IsFinished());
 }

--- a/paragraph/scheduling/subroutine_fsm_test.cc
+++ b/paragraph/scheduling/subroutine_fsm_test.cc
@@ -76,6 +76,7 @@ TEST(SubroutineFsm, StateTransition) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
+  CHECK_OK(scheduler->Init());
   EXPECT_TRUE(scheduler->GetFsm(sub_ptr).IsScheduled());
 
   scheduler->GetFsm(sub_ptr).SetBlocked();
@@ -118,6 +119,7 @@ TEST(SubroutineFsm, ExecutionCount) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
+  CHECK_OK(scheduler->Init());
   EXPECT_EQ(scheduler->GetFsm(sub_ptr).GetExecutionCount(), 1);
   EXPECT_EQ(scheduler->GetFsm(body_ptr).GetExecutionCount(), 3);
   EXPECT_EQ(scheduler->GetFsm(cond_ptr).GetExecutionCount(), 3);
@@ -149,6 +151,7 @@ TEST(SubroutineFsm, ResetState) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
+  CHECK_OK(scheduler->Init());
 
   EXPECT_TRUE(scheduler->GetFsm(instr_1).IsReady());
   EXPECT_TRUE(scheduler->GetFsm(instr_2).IsBlocked());
@@ -202,6 +205,7 @@ TEST(SubroutineFsm, PrepareToSchedule) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
+  CHECK_OK(scheduler->Init());
   // Consume first available instruction, which is dummy
   auto consumed_instructions = scheduler->GetReadyInstructions();
 
@@ -224,6 +228,7 @@ TEST(SubroutineFsm, InstructionFinished) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
+  CHECK_OK(scheduler->Init());
   EXPECT_EQ(scheduler->GetFsm(sub_ptr).GetExecutionCount(), 1);
   EXPECT_TRUE(scheduler->GetFsm(sub_ptr).IsScheduled());
   // Consume first available instruction, which is dummy

--- a/paragraph/scheduling/subroutine_fsm_test.cc
+++ b/paragraph/scheduling/subroutine_fsm_test.cc
@@ -76,7 +76,7 @@ TEST(SubroutineFsm, StateTransition) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
-  CHECK_OK(scheduler->Init());
+  CHECK_OK(scheduler->Initialize(0.0));
   EXPECT_TRUE(scheduler->GetFsm(sub_ptr).IsScheduled());
 
   scheduler->GetFsm(sub_ptr).SetBlocked();
@@ -119,7 +119,7 @@ TEST(SubroutineFsm, ExecutionCount) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
-  CHECK_OK(scheduler->Init());
+  CHECK_OK(scheduler->Initialize(0.0));
   EXPECT_EQ(scheduler->GetFsm(sub_ptr).GetExecutionCount(), 1);
   EXPECT_EQ(scheduler->GetFsm(body_ptr).GetExecutionCount(), 3);
   EXPECT_EQ(scheduler->GetFsm(cond_ptr).GetExecutionCount(), 3);
@@ -151,7 +151,7 @@ TEST(SubroutineFsm, ResetState) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
-  CHECK_OK(scheduler->Init());
+  CHECK_OK(scheduler->Initialize(0.0));
 
   EXPECT_TRUE(scheduler->GetFsm(instr_1).IsReady());
   EXPECT_TRUE(scheduler->GetFsm(instr_2).IsBlocked());
@@ -205,7 +205,7 @@ TEST(SubroutineFsm, PrepareToSchedule) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
-  CHECK_OK(scheduler->Init());
+  CHECK_OK(scheduler->Initialize(0.0));
   // Consume first available instruction, which is dummy
   auto consumed_instructions = scheduler->GetReadyInstructions();
 
@@ -228,7 +228,7 @@ TEST(SubroutineFsm, InstructionFinished) {
 
   ASSERT_OK_AND_ASSIGN(auto scheduler,
                        paragraph::GraphScheduler::Create(graph.get()));
-  CHECK_OK(scheduler->Init());
+  CHECK_OK(scheduler->Initialize(0.0));
   EXPECT_EQ(scheduler->GetFsm(sub_ptr).GetExecutionCount(), 1);
   EXPECT_TRUE(scheduler->GetFsm(sub_ptr).IsScheduled());
   // Consume first available instruction, which is dummy


### PR DESCRIPTION
    Updated Scheduler API with timings from simulator
    
    Added Init(seconds) and InstructionStarted(instruction, seconds)
    methods, and seconds parameter to InstructionFinished method. Now
    simulator is supposed to initialize scheduler before its first use and
    set scheduler time there (set to 0.0 seconds by default), and update
    scheduler time every time some instruction starts or finishes.
    Each InstructionFsm keeps timings for when instruction became ready,
    started or finished execution in simulator.