### PR TITLE
Explicitly disable layering check for hlo bridge

### DIFF
--- a/paragraph/bridging/hlo/BUILD
+++ b/paragraph/bridging/hlo/BUILD
@@ -1,4 +1,7 @@
-package(licenses = ["notice"])
+package(
+    features = ["-layering_check"],
+    licenses = ["notice"],
+)
 
 cc_library(
     name = "hlo_converter",


### PR DESCRIPTION
This puts layering check inline with Tensorflow behavior. Turning
layering check on (is on by default for internal google builds) requires
sourcing hlo targets from many places across xla source code, with many
of these targets being private and inaccessible, instead of most of
what's needed from xla client target.

For more information see [Tensorflow Issue](https://github.com/tensorflow/tensorflow/commit/892bbc9797710e78cede18ba4baae3c4185ea2a9)